### PR TITLE
Support URLs without version number

### DIFF
--- a/background.js
+++ b/background.js
@@ -13,7 +13,7 @@ chrome.browserAction.onClicked.addListener(function(activeTab)
         }
 
         // get arxiv iv
-        re = /(\d+\.\d+v?\d)/i
+        re = /(\d+\.\d+(v\d+)?)/i
         found = url.match(re)[0]
 
         // construct new url


### PR DESCRIPTION
The original code would work for a URL with a version number, like this:

```https://arxiv.org/abs/1808.00060v1```

but would fail if the version number was absent, like this:

```https://arxiv.org/abs/1808.00060```

With this change, it works for both.